### PR TITLE
fix(assets): load audio by direct import

### DIFF
--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -1,3 +1,5 @@
+import selectAudio from '../assets/select.ogg';
+
 class TitleScene extends Phaser.Scene {
     constructor() {
         super('TitleScene');
@@ -6,7 +8,7 @@ class TitleScene extends Phaser.Scene {
     preload() {
         // Sound effect from https://opengameart.org/content/8-bit-retro-sfx
         // Credit to MouthlessGames
-        this.load.audio('select', 'assets/select.ogg');
+        this.load.audio('select', selectAudio);
     }
 
     create() {


### PR DESCRIPTION
Refactors the asset loading in `TitleScene.js` to use a direct JavaScript import for the audio file.

Previously, the asset was loaded using a hardcoded string path (`'assets/select.ogg'`). This path was not being correctly resolved by the build process when deployed to a subdirectory on GitHub Pages, leading to 404 errors.

By importing the asset (`import selectAudio from '../assets/select.ogg'`), we leverage the Vite build tool to manage the asset's path. Vite replaces the import with the correct, final URL at build time, ensuring the asset can always be found. This is the standard and most robust way to handle static assets in a Vite project.