### PR TITLE
fix(build): correct relative path for audio import

### DIFF
--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -1,3 +1,5 @@
+import selectAudio from '../../assets/select.ogg';
+
 class TitleScene extends Phaser.Scene {
     constructor() {
         super('TitleScene');
@@ -6,7 +8,7 @@ class TitleScene extends Phaser.Scene {
     preload() {
         // Sound effect from https://opengameart.org/content/8-bit-retro-sfx
         // Credit to MouthlessGames
-        this.load.audio('select', 'assets/select.ogg');
+        this.load.audio('select', selectAudio);
     }
 
     create() {


### PR DESCRIPTION
Corrects the relative import path for `select.ogg` in `src/scenes/TitleScene.js`.

The previous path (`../assets/select.ogg`) was incorrect, as the `assets` directory is two levels up from `src/scenes/`, not one. This caused the Vite build to fail with a "Could not resolve" error.

The path has been corrected to `../../assets/select.ogg`, which allows the Vite bundler to correctly locate the file and manage its path for the production build.